### PR TITLE
Add "Information Hidden in Gradients of Regression with Target Noise" to all_publications.bib

### DIFF
--- a/all_publications.bib
+++ b/all_publications.bib
@@ -1,3 +1,11 @@
+@inproceedings{jamshidi2026information,
+  title={Information Hidden in Gradients of Regression with Target Noise},
+  author={Jamshidi, Arash and Haitsiukevich, Katsiaryna and Puolam{\"a}ki, Kai},
+  booktitle={International Conference on Artificial Intelligence and Statistics},  
+  year={2026},
+  arxiv={https://arxiv.org/abs/2601.18546},
+}
+
 @inproceedings{williams2026simplex,
   title={Simplex-to-Euclidean Bijections for Categorical Flow Matching},
   author={Williams, Bernardo and Yeom-Song, Victor M and Hartmann, Marcelo and Klami, Arto},

--- a/all_publications.bib
+++ b/all_publications.bib
@@ -1,6 +1,6 @@
 @inproceedings{jamshidi2026information,
   title={Information Hidden in Gradients of Regression with Target Noise},
-  author={Jamshidi, Arash and Haitsiukevich, Katsiaryna and Puolam{\"a}ki, Kai},
+  author={Arash Jamshidi and Katsiaryna Haitsiukevich and Kai Puolam{\"a}ki},
   booktitle={International Conference on Artificial Intelligence and Statistics},  
   year={2026},
   arxiv={https://arxiv.org/abs/2601.18546},


### PR DESCRIPTION
Add "Information Hidden in Gradients of Regression with Target Noise" to all_publications.bib
Accepted at AISTATS 2026